### PR TITLE
Found a potential bug

### DIFF
--- a/relayer/src/main/scala/io/lightcone/relayer/actors/EthereumEventExtractorActor.scala
+++ b/relayer/src/main/scala/io/lightcone/relayer/actors/EthereumEventExtractorActor.scala
@@ -105,7 +105,7 @@ class EthereumEventExtractorActor(
         onlineBlock <- getBlockData(blockData.number)
       } yield {
         blockData = onlineBlock.get
-        if (dbBlock.map(_.hash) == onlineBlock.map(_.hash))
+        if (dbBlock.map(_.hash) == onlineBlock.map(_.parentHash))
           self ! GET_BLOCK
         else
           self ! BLOCK_REORG_DETECTED


### PR DESCRIPTION
This is a tiny change that may be a bug. I was looking through your `reorg` code and noticed that when you're traversing backwards that you check if the previous block's hash is equal to the current block hash.

This may be intentional, but figured I would open a PR for you to check it out.